### PR TITLE
setup.py: fix the .whl missing gluestick.models (minified)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools" ]
+
+[project]
+name = "gluestick"
+version = "0.0.0"
+
+[tool.setuptools.packages.find]
+include = [ "gluestick", "gluestick.*" ]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup(name='gluestick', version="0.0", packages=['gluestick', 'gluestick.models'])

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name='gluestick', version="0.0", packages=['gluestick'])
+setup(name='gluestick', version="0.0", packages=['gluestick', 'gluestick.models'])


### PR DESCRIPTION
Setuptools does not by default include nested "packages", and the `setup.py` currently only specifies the top-level `gluestick`. This means that

```
❯ pip wheel git+https://github.com/cvg/GlueStick
```

...won't include the nested `gluestick.models`