### PR TITLE
bugfix in wf line scores

### DIFF
--- a/gluestick/models/wireframe.py
+++ b/gluestick/models/wireframe.py
@@ -249,7 +249,7 @@ class SPWireframeDescriptor(BaseModel):
                 'lines': lines,
                 'orig_lines': orig_lines,
                 'lines_junc_idx': lines_junc_idx,
-                'line_scores': line_scores,
+                'line_scores': line_pts_scores[:, ::2],
                 'valid_lines': valid_lines}
 
     @staticmethod


### PR DESCRIPTION
since we update the lines order according to the junctions, you've forgotten to update the line scores accordingly